### PR TITLE
Streamline file imports (issue #1)

### DIFF
--- a/src/prepare_court_data.py
+++ b/src/prepare_court_data.py
@@ -8,8 +8,11 @@ from bs4 import BeautifulSoup
 # CiteGeist uses tfidf as part of its ranking and isn't currently helpful to my project
 # df = pd.read_table('data/citegeist', header=None, names=['rating'], delimiter='=', index_col=0)
 
-# Extract the json files from tar.gz files and return a DataFrame
-def create_df_from_tar(files_tar, length=None):
+
+def create_list_from_tar(files_tar, length=None):
+    '''
+    Extract the json files from tar.gz files and return a list of selected data
+    '''
     json_list = []
 
     with tarfile.open(files_tar, mode='r:gz') as tf_files:
@@ -46,6 +49,11 @@ def create_df_from_tar(files_tar, length=None):
     return json_list
 
 def reverse_stem(resource_id, opinion_df, opinion_cv_model, df_stems):
+    '''
+    Take the stemmed words in a document and return the possible words (from all documents) that could 
+    could have been used to create the stem. This doesn't (yet) take into account whether the specific 
+    words actually exist in the current document.
+    '''
     row = opinion_df.filter(opinion_df.resource_id == resource_id).first()
     term_stems = np.array(opinion_cv_model.vocabulary)[row['token_idf'].indices[np.argsort(row['token_idf'].values)]][:-11:-1]
     word_lists = []

--- a/src/prepare_court_data.py
+++ b/src/prepare_court_data.py
@@ -73,3 +73,10 @@ def create_df(tar_file, length=None):
     '''
     pass
     
+def import_opinions():
+    tf_path = 'data/opinions_wash.tar.gz'
+    tf = tarfile.open(tf_path, mode='r:gz')
+    for f in tf:
+        lst.append(tf.extractfile(f).readline())
+    
+    tf.close()

--- a/src/prepare_court_data.py
+++ b/src/prepare_court_data.py
@@ -60,3 +60,16 @@ def reverse_stem(resource_id, opinion_df, opinion_cv_model, df_stems):
     for stem in term_stems:
         word_lists.append(df_stems.select('terms').filter(df_stems.stem == stem).first()[0])
     return word_lists
+
+def create_df(tar_file, length=None):
+    '''
+    Use Spark to import files from a tarfile and store the json information directly into a Spark dataframe. 
+    
+    This should replace the previous function: create_list_from_tar()
+    
+    First, loop through the TarInfo objects to get filenames rather than loading the whole list of names at once. 
+    Second, load each file one at a time to parallelize them, rather than loading all the files into memory.
+    Finally, read the json and separate the fields into columns if possible.
+    '''
+    pass
+    

--- a/src/prepare_court_data.py
+++ b/src/prepare_court_data.py
@@ -6,10 +6,6 @@ from bs4 import BeautifulSoup
 from pyspark.sql.types import StructType, StructField, IntegerType, StringType, \
         FloatType, ArrayType, BooleanType
 
-# Import the CiteGeist file into a dataframe
-# CiteGeist uses tfidf as part of its ranking and isn't currently helpful to my project
-# df = pd.read_table('data/citegeist', header=None, names=['rating'], delimiter='=', index_col=0)
-
 
 def create_list_from_tar(files_tar, length=None):
     '''
@@ -63,19 +59,18 @@ def reverse_stem(resource_id, opinion_df, opinion_cv_model, df_stems):
         word_lists.append(df_stems.select('terms').filter(df_stems.stem == stem).first()[0])
     return word_lists
 
-def create_df(tar_file, length=None):
-    '''
-    Use Spark to import files from a tarfile and store the json information directly into a Spark dataframe. 
-    
-    This should replace the previous function: create_list_from_tar()
-    
-    First, loop through the TarInfo objects to get files rather than loading the whole list of names at once. 
-    Second, load each file one at a time to parallelize them, rather than loading all the files into memory.
-    Finally, read the json and separate the fields into columns if possible.
-    '''
-    pass
-    
 def import_opinions_as_dataframe(tf_path = 'data/opinions_wash.tar.gz'):
+    '''
+    Import the data from a tar.gz file. Use a generator so the data isn't loaded until necessary.
+
+    The tarfile module provides a TarInfo object that can be used to identify each file for extraction.
+    The extractfile() method returns a file object that has a read() method which returns a byte 
+    representation of the file which can be decoded into a string. The string can then be translated
+    into a dict by json.loads(). Each json object in dict form can be read into the dataframe.
+
+    The schema is important because inferring the data type from a dict is deprecated in Spark and 
+    sometimes assumes the wrong type.
+    '''
 
     fields = [
             StructField('absolute_url', StringType(), True),

--- a/src/prepare_court_data.py
+++ b/src/prepare_court_data.py
@@ -27,6 +27,10 @@ def create_df_from_tar(files_tar, length=None):
             elif json_itm.get('html_lawbox'):
                 json_itm['html_lawbox'] = json_itm['html_lawbox'].replace('<blockquote>', '"').replace('</blockquote>', '"')
                 json_itm['parsed_text'] = BeautifulSoup(json_itm.get('html_lawbox'), 'lxml').text
+            elif json_itm.get('html_with_citations'):
+                json_itm['html_with_citations'] = json_itm['html_with_citations'].replace('<blockquote>', '"') \
+                        .replace('</blockquote>', '"')
+                json_itm['html_with_citations'] = BeautifulSoup(json_itm.get('html_with_citations'), 'lxml').text
             elif json_itm.get('plain_text'):
                 json_itm['parsed_text'] = json_itm.get('plain_text')
 

--- a/src/prepare_court_data.py
+++ b/src/prepare_court_data.py
@@ -67,7 +67,7 @@ def create_df(tar_file, length=None):
     
     This should replace the previous function: create_list_from_tar()
     
-    First, loop through the TarInfo objects to get filenames rather than loading the whole list of names at once. 
+    First, loop through the TarInfo objects to get files rather than loading the whole list of names at once. 
     Second, load each file one at a time to parallelize them, rather than loading all the files into memory.
     Finally, read the json and separate the fields into columns if possible.
     '''
@@ -75,8 +75,10 @@ def create_df(tar_file, length=None):
     
 def import_opinions():
     tf_path = 'data/opinions_wash.tar.gz'
-    tf = tarfile.open(tf_path, mode='r:gz')
-    for f in tf:
-        lst.append(tf.extractfile(f).readline())
-    
-    tf.close()
+    json_dict = []
+
+    with tarfile.open(tf_path, mode='r:gz') as tf:
+        for f in tf:
+            json_dict.append(json.loads(tf.extractfile(f).read().decode()))
+
+    return json_dict

--- a/src/spark.py
+++ b/src/spark.py
@@ -95,3 +95,5 @@ raw_opinion_df = import_opinions_as_dataframe()
 raw_opinion_df_nonull = raw_opinion_df.fillna('', ['html', 'html_columbia', 'html_lawbox', 'html_with_citations', 'plain_text'])
 raw_opinion_df_combined_text = raw_opinion_df_nonull.withColumn('text', concat(
     col('html'), col('html_lawbox'), col('html_columbia'), col('html_with_citations'), col('plain_text')))
+udfBS4 = udf(lambda cell: BeautifulSoup(cell, 'lxml').text, StringType())
+opinion_df = raw_opinion_df_combined_text.withColumn('parsed_text', udfBS4(col('text')))

--- a/src/spark.py
+++ b/src/spark.py
@@ -89,3 +89,9 @@ df_stems.select('terms').filter(df_stems.stem == opinion_stemm.stem('artful')).f
 # create a count for each opinion of the number of times it has been cited by other Washington opinions
 df_citecount = spark.createDataFrame(opinion_df.select(explode(opinion_df.opinions_cited).alias('cites')).groupBy('cites').agg({"*": "count"}).collect())
 df_citecount.orderBy('count(1)', ascending=False).show()
+
+# fill in null values for opinion text and then join them into one column, then drop the redundant columns
+raw_opinion_df = import_opinions_as_dataframe()
+raw_opinion_df_nonull = raw_opinion_df.fillna('', ['html', 'html_columbia', 'html_lawbox', 'html_with_citations', 'plain_text'])
+raw_opinion_df_combined_text = raw_opinion_df_nonull.withColumn('text', concat(
+    col('html'), col('html_lawbox'), col('html_columbia'), col('html_with_citations'), col('plain_text')))

--- a/src/spark.py
+++ b/src/spark.py
@@ -12,7 +12,7 @@ from pyspark.sql.functions import udf, col, explode, collect_list
 
 
 # create an RDD from the data, choose number of rows to include
-opinion_lst = prepare_court_data.create_df_from_tar('data/opinions_wash.tar.gz', 100)
+opinion_lst = prepare_court_data.create_list_from_tar('data/opinions_wash.tar.gz', 100)
 opinion_rdd = sc.parallelize(opinion_lst, 15)
 
 # define the subset of columns to use and write it into a schema


### PR DESCRIPTION
Currently files are imported using only one python process and result in some opinions having no text imported. 
- use Spark to take advantage of multiple processors
- combine information from all the text fields unless it is duplicated